### PR TITLE
Bug 1016030 - Fix Mulet's support

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ Host.prototype = {
     userOptions.profile = userOptions.profile || profile;
     userOptions.product = userOptions.product || 'b2g';
     userOptions.runtime = this.options.customRuntime;
+    userOptions.chrome = 'chrome://b2g/content/shell.html';
 
     debug('start');
     var self = this;


### PR DESCRIPTION
Based on top of https://github.com/mozilla-b2g/marionette-b2gdesktop-host/pull/13

It happens to change nothing for b2g desktop as shell.html is already the default chrome document,
but it allows to easily run tests on mulet.
